### PR TITLE
Add support for setting import ordinals

### DIFF
--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -776,7 +776,7 @@ BOOL WINAPI DetourUpdateProcessWithDllEx2(_In_ HANDLE hProcess,
     //
     BOOL bIs32BitExe = FALSE;
 
-    DETOUR_TRACE(("DetourUpdateProcessWithDllEx(%p,%p,dlls=%lu)\n", hProcess, hModule, nDlls));
+    DETOUR_TRACE(("DetourUpdateProcessWithDllEx2(%p,%p,dlls=%lu)\n", hProcess, hModule, nDlls));
 
     IMAGE_NT_HEADERS32 inh;
 
@@ -940,6 +940,8 @@ BOOL WINAPI DetourUpdateDllWithDll(_In_ HANDLE hProcess,
         return FALSE;
     }
 
+    DETOUR_TRACE(("DetourUpdateDllWithDll(%p,%p,dlls=%lu)\n", hProcess, hImage, nDlls));
+
     // Find the next memory region that contains a mapped PE image.
     //
     WORD mach32Bit = 0;
@@ -954,14 +956,14 @@ BOOL WINAPI DetourUpdateDllWithDll(_In_ HANDLE hProcess,
             break;
         }
 
-        DETOUR_TRACE(("%p  machine=%04x magic=%04x\n",
+        DETOUR_TRACE(("Module:%p  machine=%04x magic=%04x\n",
             hLast, inh.FileHeader.Machine, inh.OptionalHeader.Magic));
 
         if ((inh.FileHeader.Characteristics & IMAGE_FILE_DLL) == 0) {
             if (inh.OptionalHeader.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
                 exe32Bit = inh.FileHeader.Machine;
             }
-            DETOUR_TRACE(("%p  Found EXE\n", hLast));
+            DETOUR_TRACE(("Module:%p  Found EXE\n", hLast));
         }
         else {
             if (inh.OptionalHeader.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC && inh.FileHeader.Machine != 0) {

--- a/src/detours.h
+++ b/src/detours.h
@@ -834,6 +834,28 @@ BOOL WINAPI DetourUpdateProcessWithDllEx(_In_ HANDLE hProcess,
                                          _In_reads_(nDlls) LPCSTR *rlpDlls,
                                          _In_ DWORD nDlls);
 
+BOOL WINAPI DetourUpdateProcessWithDllEx2(_In_ HANDLE hProcess,
+                                          _In_ HMODULE hImage,
+                                          _In_ BOOL bIs32Bit,
+                                          _In_reads_(nDlls) LPCSTR *rlpDlls,
+                                          _In_reads_opt_(nDlls) DWORD* pdwOrdinals,
+                                          _In_ DWORD nDlls);
+
+BOOL WINAPI DetourInjectProcessWithDll(_In_ HANDLE hProcess,
+                                       _In_ LPCSTR pszDllName,
+                                       _In_ DWORD dwOrdinal);
+
+BOOL WINAPI DetourUpdateDllWithDll(_In_ HANDLE hProcess,
+                                   _In_ HMODULE hImage,
+                                   _In_reads_(nDlls) LPCSTR* rlpDlls,
+                                   _In_reads_opt_(nDlls) DWORD* pdwOrdinals,
+                                   _In_ DWORD nDlls);
+
+BOOL WINAPI DetourInjectDllWithDll(_In_ HANDLE hProcess,
+                                   _In_ HMODULE hImage,
+                                   _In_ LPCSTR pszDllName,
+                                   _In_ DWORD dwOrdinal);
+
 BOOL WINAPI DetourCopyPayloadToProcess(_In_ HANDLE hProcess,
                                        _In_ REFGUID rguid,
                                        _In_reads_bytes_(cbData) LPCVOID pvData,

--- a/src/uimports.cpp
+++ b/src/uimports.cpp
@@ -18,6 +18,7 @@
 static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
                               HMODULE hModule,
                               __in_ecount(nDlls) LPCSTR *plpDlls,
+                              __in_ecount_opt(nDlls) DWORD* pdwOrdinals,
                               DWORD nDlls)
 {
     BOOL fSucceeded = FALSE;
@@ -245,13 +246,13 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
         // We need 2 thunks for the import table and 2 thunks for the IAT.
         // One for an ordinal import and one to mark the end of the list.
         pt = ((IMAGE_THUNK_DATAXX*)(pbNew + nOffset));
-        pt[0].u1.Ordinal = IMAGE_ORDINAL_FLAG_XX + 1;
+        pt[0].u1.Ordinal = IMAGE_ORDINAL_FLAG_XX + (pdwOrdinals ? pdwOrdinals[n] : 1);
         pt[1].u1.Ordinal = 0;
 
         nOffset = obTab + (sizeof(IMAGE_THUNK_DATAXX) * ((4 * n) + 2));
         piid[n].FirstThunk = obBase + nOffset;
         pt = ((IMAGE_THUNK_DATAXX*)(pbNew + nOffset));
-        pt[0].u1.Ordinal = IMAGE_ORDINAL_FLAG_XX + 1;
+        pt[0].u1.Ordinal = IMAGE_ORDINAL_FLAG_XX + (pdwOrdinals ? pdwOrdinals[n] : 1);
         pt[1].u1.Ordinal = 0;
         piid[n].TimeDateStamp = 0;
         piid[n].ForwarderChain = 0;


### PR DESCRIPTION
This change is largely about being able to control the import ordinal set in `UPDATE_IMPORTS_XX`, but also includes a new function `DetourUpdateDllWithDll` which is similar to `DetourUpdateProcessWithDllEx`.

Additional parameters for `DetourUpdateProcessWithDllEx` are added to make `DetourUpdateProcessWithDllEx2`.  I wasn't sure what the natural next name was for post-`Ex` (I assume it isn't `ExEx`).